### PR TITLE
Allow everyone with write permission to push to main

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -339,9 +339,6 @@ branch_protection_templates:
       require_code_owner_reviews: false
       required_approving_review_count: 1
     restrictions:
-      users: []  # list of members or empty list
-      teams: []  # list of teams or empty list
-      apps: []  # list of app slugs with push access
     required_linear_history: false
     allow_force_pushes: false
     allow_deletions: false


### PR DESCRIPTION
This allows everyone with write permission (i.e. everyone in our organization) to write to the main branch. Changes still need to be first pushed to a unprotected branch and reviewed in a pull request, but clicking on the merge button is now possible for everyone aside the admin/maintainer team.

See https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/about-protected-branches#restrict-who-can-push-to-matching-branches for more information on this change.

>  When status checks are required, the people, teams, and apps that have permission to push to a protected branch will still be prevented from merging into the branch when the required checks fail. People, teams, and apps that have permission to push to a protected branch will still need to create a pull request when pull requests are required.

Signed-off-by: Eduard Itrich <eduard@itrich.net>