### PR TITLE
Add second branch protection rule that only allows owners to merge

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -342,3 +342,24 @@ branch_protection_templates:
     required_linear_history: false
     allow_force_pushes: false
     allow_deletions: false
+  owner_only:
+    required_status_checks:
+      strict: true
+      checks:
+        - context: "DCO"
+          app_id: 29752456
+    enforce_admins: true
+    required_pull_request_reviews:
+      dismissal_restrictions:
+        users: []  # list of members or empty list
+        teams: []  # list of teams or empty list
+      dismiss_stale_reviews: true
+      require_code_owner_reviews: false
+      required_approving_review_count: 1
+    restrictions:
+      users: []  # list of members or empty list
+      teams: []  # list of teams or empty list
+      apps: []  # list of app slugs with push access
+    required_linear_history: false
+    allow_force_pushes: false
+    allow_deletions: false

--- a/orgs/SovereignCloudStack/repositories/github-manager.yml
+++ b/orgs/SovereignCloudStack/repositories/github-manager.yml
@@ -19,4 +19,4 @@ github-manager:
   collaborators: []
   branch_protections:
     - branch: "main"
-      template: "main"
+      template: "owner_only"


### PR DESCRIPTION
Since merging into the `main` branch of `github-manager` needs a valid PAT to make the CI run succeed, this PR adds a second branch protection rules that only allows owners to merge changes into main.

Signed-off-by: Eduard Itrich <eduard@itrich.net>