### PR TITLE
Add a branch protection rule that can be bypassed by owners

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -425,3 +425,21 @@ branch_protection_templates:
     required_linear_history: false
     allow_force_pushes: false
     allow_deletions: false
+  owner_bypass:
+    required_status_checks:
+      strict: true
+      checks:
+        - context: "DCO"
+          app_id: 29752456
+    enforce_admins: false
+    required_pull_request_reviews:
+      dismissal_restrictions:
+        users: []  # list of members or empty list
+        teams: []  # list of teams or empty list
+      dismiss_stale_reviews: true
+      require_code_owner_reviews: false
+      required_approving_review_count: 1
+    restrictions:
+    required_linear_history: false
+    allow_force_pushes: false
+    allow_deletions: false

--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -443,3 +443,4 @@ branch_protection_templates:
     required_linear_history: false
     allow_force_pushes: false
     allow_deletions: false
+    

--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -443,4 +443,3 @@ branch_protection_templates:
     required_linear_history: false
     allow_force_pushes: false
     allow_deletions: false
-    

--- a/orgs/SovereignCloudStack/repositories/newsletter.yml
+++ b/orgs/SovereignCloudStack/repositories/newsletter.yml
@@ -18,4 +18,4 @@ newsletter:
   collaborators: []
   branch_protections:
     - branch: "main"
-      template: "main"
+      template: "owner_bypass"

--- a/orgs/SovereignCloudStack/repositories/website.yml
+++ b/orgs/SovereignCloudStack/repositories/website.yml
@@ -18,4 +18,4 @@ website:
   collaborators: []
   branch_protections:
     - branch: "main"
-      template: "main"
+      template: "owner_bypass"


### PR DESCRIPTION
We have some repositories (e.g. `newsletter` or `website`) there either changes have to be made quite fast or reviews would block the process of publishing). I'd thus propose to add a branch protection rule that can be bypassed by owners. However, we should be very scarce in distributing this particular rule.