### PR TITLE
Archive ort-docker

### DIFF
--- a/orgs/SovereignCloudStack/repositories/ort-docker.yml
+++ b/orgs/SovereignCloudStack/repositories/ort-docker.yml
@@ -5,7 +5,7 @@ ort-action:
   homepage: 'https://scs.community/'
   topics:
     - oss-review-toolkit
-  archived: false
+  archived: true
   has_issues: true
   has_projects: false
   has_wiki: false


### PR DESCRIPTION
The ORT community actively maintains a GitHub Action at https://github.com/oss-review-toolkit/ort-ci-github-action that is far more advanced than this implementation. We should archive this repository and switch to the upstream GitHub Action. See https://github.com/oss-review-toolkit/ort/issues/3512 for reference.