### PR TITLE
Don't dismiss stale reviews

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -402,7 +402,7 @@ branch_protection_templates:
       dismissal_restrictions:
         users: []  # list of members or empty list
         teams: []  # list of teams or empty list
-      dismiss_stale_reviews: true
+      dismiss_stale_reviews: false
       require_code_owner_reviews: false
       required_approving_review_count: 1
     restrictions:
@@ -420,7 +420,7 @@ branch_protection_templates:
       dismissal_restrictions:
         users: []  # list of members or empty list
         teams: []  # list of teams or empty list
-      dismiss_stale_reviews: true
+      dismiss_stale_reviews: false
       require_code_owner_reviews: false
       required_approving_review_count: 1
     restrictions:
@@ -441,7 +441,7 @@ branch_protection_templates:
       dismissal_restrictions:
         users: []  # list of members or empty list
         teams: []  # list of teams or empty list
-      dismiss_stale_reviews: true
+      dismiss_stale_reviews: false
       require_code_owner_reviews: false
       required_approving_review_count: 1
     restrictions:


### PR DESCRIPTION
This is really a blocker on how we currently work. Especially if minor "beauty" fixes are made after a review, this can be annoying. Since we're rather a small group that can be trusted, I'd propose to remove the dismissal of stale reviews.