### PR TITLE
Switch to Action by @JasonEtco that checks for existing issues

### DIFF
--- a/.github/unmanaged-repos-issue.md
+++ b/.github/unmanaged-repos-issue.md
@@ -2,4 +2,4 @@
 title: There are unmanaged repositories
 labels: housekeeping
 ---
-${{ steps.check.outputs.stderr }}
+${{ steps.check.outputs.CHECK_RESULT }}

--- a/.github/unmanaged-repos-issue.md
+++ b/.github/unmanaged-repos-issue.md
@@ -1,0 +1,5 @@
+---
+title: There are unmanaged repositories
+labels: housekeeping
+---
+${{ steps.check.outputs.stderr }}

--- a/.github/workflows/check-unmanaged-repos.yml
+++ b/.github/workflows/check-unmanaged-repos.yml
@@ -30,18 +30,13 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+          cache: 'pipenv'
 
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
           python3 -m pip install pipenv wheel
           pipenv install
-
-      - name: Cache pipenv
-        uses: actions/cache@v1
-        with:
-          path: ~/.local/share/virtualenvs
-          key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Call check_repositories.py
         run: |

--- a/.github/workflows/check-unmanaged-repos.yml
+++ b/.github/workflows/check-unmanaged-repos.yml
@@ -44,10 +44,9 @@ jobs:
           key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
 
       - name: Call check_repositories.py
-        uses: mathiasvr/command-output@v1
+        run: |
+          echo "CHECK_RESULT=$(pipenv run python3 check_repositories.py 2>&1)" >> $GITHUB_OUTPUT
         id: check
-        with:
-          run: pipenv run python3 check_repositories.py
         env:
           API_TOKEN: ${{ secrets[format('GHP_{0}', github.actor)] }}
 

--- a/.github/workflows/check-unmanaged-repos.yml
+++ b/.github/workflows/check-unmanaged-repos.yml
@@ -53,10 +53,11 @@ jobs:
 
       - name: Create issue on failed workflow
         if: ${{ failure() }}
-        uses: dacbd/create-issue-action@main
+        uses: JasonEtco/create-an-issue@v2
         with:
-          token: ${{ github.token }}
-          title: There are unmanaged repositories
-          body: |
-            ${{ steps.check.outputs.stderr }}
+          filename: .github/unmanaged-repos-issue.md
+          update_existing: true
           assignees: itrich
+          search_existing: open
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The current Action we use to create an issue will create an issue every time the workflows runs/fails. We should switch to https://github.com/marketplace/actions/create-an-issue by @JasonEtco that searches for existing (open) issues in order to not have a myriad of open issues after some days.