### PR TITLE
Allow owner to bypass standards branch protection rules

### DIFF
--- a/orgs/SovereignCloudStack/repositories/standards.yml
+++ b/orgs/SovereignCloudStack/repositories/standards.yml
@@ -18,4 +18,4 @@ standards:
   collaborators: []
   branch_protections:
     - branch: "main"
-      template: "main"
+      template: "owner_bypass"


### PR DESCRIPTION
This change is needed so that a GitHub Action workflow is able to push changes to main branch without having to create a PR.