### PR TITLE
Add repos for SCS Cluster Stacks

### DIFF
--- a/orgs/SovereignCloudStack/repositories/cluster-stack-operator.yml
+++ b/orgs/SovereignCloudStack/repositories/cluster-stack-operator.yml
@@ -1,0 +1,21 @@
+---
+cluster-stack-operator:
+  default_branch: main
+  description: The SCS Cluster Stack Operator takes care of life cycle management, configuration and provider specific tasks of Kubernetes clusters created with SCS Cluster Stacks
+  homepage: 'https://scs.community/'
+  topics:
+    - k8s
+  archived: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  private: false
+  delete_branch_on_merge: true
+  allow_merge_commit: false
+  allow_squash_merge: true
+  allow_rebase_merge: true
+  teams: []
+  collaborators: []
+  branch_protections:
+    - branch: "main"
+      template: "main"

--- a/orgs/SovereignCloudStack/repositories/cluster-stacks.yml
+++ b/orgs/SovereignCloudStack/repositories/cluster-stacks.yml
@@ -1,0 +1,21 @@
+---
+cluster-stacks:
+  default_branch: main
+  description: Definition of Cluster Stacks based on the ClusterAPI ClusterClass feature
+  homepage: 'https://scs.community/'
+  topics:
+    - k8s
+  archived: false
+  has_issues: true
+  has_projects: false
+  has_wiki: false
+  private: false
+  delete_branch_on_merge: true
+  allow_merge_commit: false
+  allow_squash_merge: true
+  allow_rebase_merge: true
+  teams: []
+  collaborators: []
+  branch_protections:
+    - branch: "main"
+      template: "main"


### PR DESCRIPTION
This PR adds the two new repositories regarding the SCS Cluster Stacks.
Basically these repositories initially represent the two Epics [issues/#321](https://github.com/SovereignCloudStack/issues/issues/321) and [issues/#326](https://github.com/SovereignCloudStack/issues/issues/326) but will certainly play a bigger role in future releases.

I decided to not use the prefix `k8s` in the name because it feels more serious for me and looks more like a product which is powered by Kubernetes not vice versa. Essentially same as e.g. OpenShift, Rancher, Tanzu...
But of course I am ready to discuss that.