### PR TITLE
Add vp06c as cspo admins

### DIFF
--- a/orgs/SovereignCloudStack/repositories/cluster-stack-provider-openstack.yml
+++ b/orgs/SovereignCloudStack/repositories/cluster-stack-provider-openstack.yml
@@ -14,7 +14,9 @@ cluster-stack-provider-openstack:
   allow_merge_commit: false
   allow_squash_merge: true
   allow_rebase_merge: true
-  teams: []
+  teams:
+    - slug: "VP06c"
+      permission: "admin"
   collaborators: []
   branch_protections:
     - branch: "main"


### PR DESCRIPTION
Hi @michal-gubricky,
looks like the role for your team @SovereignCloudStack/vp06c was removed from the github manager again.
With this we should keep it.