### PR TITLE
Add team cluster admins for use in kubernetes

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -618,6 +618,16 @@ teams:
       - DMackJH
       - RLeibJH
       - osfrickler
+  - slug: "cluster-admins"
+    description: "Kubernetes Admins on shared clusters which use GitHub as auth service"
+    privacy: closed
+    maintainer:
+      - jschoone
+    member:
+      - bitkeks
+      - fkr
+      - garloff
+      - scoopex
 
 # ==========================
 branch_protection_templates:


### PR DESCRIPTION
For simplicity we use GitHub as external auth service in our shared Kubernetes cluster. Hopefully temporarily until we have a prod Keycloak which can be used, but it's also possible to use both in the same cluster.
To make it easier to give someone cluster-admin permissions, this can be requested with a PR on this GitHub team.
The name `cluster-admins` was chosen over something like `kube-admin` in reference to the Kubernetes ClusterRole `cluster-admin`.