### PR TITLE
Add Zuul Admin Group

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -688,6 +688,17 @@ teams:
     member:
       - dominikkaminski
       - securitykernel
+  - slug: "Zuul-Admins"
+    description: "Admins of the Zuul CI System"
+    privacy: closed
+    maintainer:
+      - o-otte
+      - PixelPhantomX
+    member:
+      - bitkeks
+      - fkr
+      - matofeder
+      - scoopex
 
 # ==========================
 branch_protection_templates:


### PR DESCRIPTION
This adds a new Group to the GitHub Manager to manage people how should be able to do administrative work on Zuul. This group will be used for the OIDC workflow to allow administation of Zuul on the Web UI.