### PR TITLE
grant gtema admin privileges

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -255,6 +255,7 @@ members:
     login: OgarOgarovic
   - name: Artem Goncharov
     login: gtema
+    role: admin
   - name: Ilja Shmelkin
     login: shmelkin
   - name: Tomas Smado


### PR DESCRIPTION
In order to be able to verify projects configuration with respect to CI/CD and forcibly and timely merge security relevant PRs grant admin privileges