### PR TITLE
Update moin-cluster-playground members

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -292,18 +292,10 @@ teams:
       - chess-knight
       - DEiselt
       - matofeder
-  - slug: "moin-cluster-playground1"
-    description: "Members of this team have access to tenant namespace playground1 moin-cluster"
-    privacy: closed
-    maintainer:
-      - mxmxchere
-    member:
-      - DEiselt
-      - chess-knight
       - garloff
       - fkr
       - scoopex
-      - martinmo
+      - curx
   - slug: "23technologies"
     description: "23technologies GmbH"
     privacy: closed


### PR DESCRIPTION
* Added missing members of playground1 to all playgrounds
* Added curx to all playgrounds
* Removed playground1 team (nobody looses access as all members have
  been moved to all-playgrounds)

Signed-off-by: Malte Münch <muench@b1-systems.de>
