### PR TITLE
sonic-buildimage has no main branch.

### DIFF
--- a/orgs/SovereignCloudStack/repositories/sonic-buildimage.yml
+++ b/orgs/SovereignCloudStack/repositories/sonic-buildimage.yml
@@ -1,6 +1,6 @@
 ---
 sonic-buildimage:
-  default_branch: main
+  default_branch: master
   description: 'A fork of the offical sonic repo'
   homepage: 'https://scs.community/'
   topics:


### PR DESCRIPTION
fixes the github-manager errors present for months.