### PR TITLE
add new empty repo: openstack-workload-generator, rework groups

### DIFF
--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -619,21 +619,9 @@ teams:
     privacy: closed
     maintainer:
       - scoopex
-      - bitkeks
-      - berendt
-  - slug: "VP18"
-    description: "The team which manages the scs system landscape or needs information about it"
-    privacy: closed
-    maintainer:
-      - scoopex
+      - fkr
     member:
       - berendt
-      - fkr
-      - BiancaHollery
-      - manuela-urban
-      - DMackJH
-      - RLeibJH
-      - osfrickler
       - zuse-z3
   - slug: "cluster-admins"
     description: "Kubernetes Admins on shared clusters which use GitHub as auth service"

--- a/orgs/SovereignCloudStack/repositories/openstack-workload-generator.yml
+++ b/orgs/SovereignCloudStack/repositories/openstack-workload-generator.yml
@@ -1,5 +1,5 @@
 ---
-rookify:
+openstack-workload-generator:
   default_branch: main
   description: 'A tool to generate domain and project structures in openstack for testing purposes'
   homepage: 'https://scs.community/'

--- a/orgs/SovereignCloudStack/repositories/openstack-workload-generator.yml
+++ b/orgs/SovereignCloudStack/repositories/openstack-workload-generator.yml
@@ -1,0 +1,26 @@
+---
+rookify:
+  default_branch: main
+  description: 'A tool to generate domain and project structures in openstack for testing purposes'
+  homepage: 'https://scs.community/'
+  topics:
+    - openstack
+    - testing
+  archived: false
+  has_issues: true
+  has_projects: false
+  has_wiki: true
+  private: false
+  delete_branch_on_merge: true
+  allow_merge_commit: false
+  allow_squash_merge: true
+  allow_rebase_merge: true
+  maintainer:
+    - scoopex
+  teams:
+    - slug: "osba"
+      permission: "admin"
+  collaborators: []
+  branch_protections:
+    - branch: "main"
+      template: "main"


### PR DESCRIPTION
I am considering to move the workload generator of the hardware-landscape to this repository.

https://github.com/SovereignCloudStack/hardware-landscape/blob/main/documentation/System_Stresstest.md