### PR TITLE
CODEOWNERS proposal

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+CODEOWNERS @org/project-board

--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -652,6 +652,15 @@ teams:
     privacy: closed
     maintainer:
       - cpt-kernel-afk
+  - slug: "project-board"
+    description: "Members of  Board"
+    privacy: closed
+    maintainer:
+      - berendt
+      - fkr
+      - garloff
+      - jschoone
+      - matofeder
 
 # ==========================
 branch_protection_templates:

--- a/orgs/SovereignCloudStack/data.yaml
+++ b/orgs/SovereignCloudStack/data.yaml
@@ -694,7 +694,7 @@ branch_protection_templates:
         users: []  # list of members or empty list
         teams: []  # list of teams or empty list
       dismiss_stale_reviews: false
-      require_code_owner_reviews: false
+      require_code_owner_reviews: true
       required_approving_review_count: 1
     restrictions:
       users: []  # list of members or empty list


### PR DESCRIPTION
As discussed in Project Board CW08, this is a proposal to test the CODEOWNERS
feature.
There is the branch restriction template `owner_only` which is only applied to
this repository and already contains an alternative to CODEOWNERS but this is
obviously not in use. That's why I just enabled the CODEOWNERS requirement
here.
Also added the project-board group and made this the code owners of the
CODEOWNERS file.
