### PR TITLE
Archive opendesk-on-scs repository

### DIFF
--- a/orgs/SovereignCloudStack/repositories/opendesk-on-scs.yml
+++ b/orgs/SovereignCloudStack/repositories/opendesk-on-scs.yml
@@ -5,7 +5,7 @@ opendesk-on-scs:
   homepage: "https://docs.scs.community/user-docs/application-examples/opendesk-on-scs/overview"
   topics:
     - documentation
-  archived: false
+  archived: true
   has_issues: true
   has_projects: false
   has_wiki: false


### PR DESCRIPTION
Sets `archived: true` for the `opendesk-on-scs` repository.

**Reasoning:** Over 2 years without changes. Archiving avoids confusing anyone searching for OpenDesk and SCS into thinking it should still work.