### PR TITLE
Archive moin-cluster-config repository

### DIFF
--- a/orgs/SovereignCloudStack/repositories/moin-cluster-config.yaml
+++ b/orgs/SovereignCloudStack/repositories/moin-cluster-config.yaml
@@ -5,7 +5,7 @@ moin-cluster-config:
   homepage: 'https://scs.community/'
   topics:
     - k8s
-  archived: false
+  archived: true
   has_issues: true
   has_projects: false
   has_wiki: false


### PR DESCRIPTION
Sets `archived: true` for the `moin-cluster-config` repository.

**Reasoning:** Archiving due to inactivity.